### PR TITLE
[cocoroboController] Add sample interface to get the feel of COCOROBO.

### DIFF
--- a/cocoroboController/cocorobo-pet/build.gradle
+++ b/cocoroboController/cocorobo-pet/build.gradle
@@ -31,3 +31,8 @@ dependencies {
 	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+javadoc {
+	options.charSet = 'UTF-8'
+	options.encoding = 'UTF-8'
+}

--- a/cocoroboController/cocorobo-pet/src/main/java/javajo/CocoroboController.java
+++ b/cocoroboController/cocorobo-pet/src/main/java/javajo/CocoroboController.java
@@ -1,0 +1,62 @@
+package javajo;
+
+import javajo.dto.FeelDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * COCOROBOのデータ取得API.
+ */
+@RestController
+@RequestMapping("/api")
+public class CocoroboController {
+
+    private final Logger log = LoggerFactory.getLogger(CocoroboController.class);
+
+    /**
+     * 指定されたCOCOROBOの感情を取得する.
+     *
+     * @param cocorobo COCOROBOの識別子：例)toko
+     * @return JSON形式の文字列：<pre>{@code
+     * {
+     *     "result": 実行結果(boolean),
+     *     "feel": 目玉の種類(String)
+     * }
+     * }</pre>
+     * <p>feelの詳細</p>
+     * <ul>
+     *     <li>mattee：待って〜！って顔</li>
+     *     <li>shoboon：置いてかれた、しょぼーん</li>
+     *     <li>waai：喜び</li>
+     *     <li>dere：デレデレ</li>
+     *     <li>tun：ツン</li>
+     * </ul>
+     */
+    @GetMapping(value = "/feels/{cocorobo}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FeelDTO> getFeel(@PathVariable String cocorobo) {
+        log.debug("REST request to get Feel : {}", cocorobo);
+
+        /* モックデータ作成開始 */
+        List<String> feel = Arrays.asList("mattee", "shoboon", "waai", "dere", "tun");
+        Collections.shuffle(feel);
+
+        FeelDTO feelDTO = new FeelDTO();
+        feelDTO.setResult(true);
+        feelDTO.setFeel(feel.get(0));
+        /* モックデータ作成終了 */
+
+        return new ResponseEntity(feelDTO, HttpStatus.OK);
+    }
+
+}

--- a/cocoroboController/cocorobo-pet/src/main/java/javajo/dto/FeelDTO.java
+++ b/cocoroboController/cocorobo-pet/src/main/java/javajo/dto/FeelDTO.java
@@ -1,0 +1,29 @@
+package javajo.dto;
+
+/**
+ * 感情取得用DTO.
+ */
+public class FeelDTO {
+
+    // 実行結果
+    private boolean result;
+
+    // 感情(目玉の種類)
+    private String feel;
+
+    public boolean isResult() {
+        return result;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public String getFeel() {
+        return feel;
+    }
+
+    public void setFeel(String feel) {
+        this.feel = feel;
+    }
+}


### PR DESCRIPTION
#32 対応

感情を取得するAPIのサンプルを追加しました。

【使用方法】
- リクエスト
  - http://javajo-erk5.azurewebsites.net/cocorobo-pet/api/feels/toko
  - ※末尾の「toko」はCOCOROBOが複数台あるので識別できるようCOCOROBOの識別子を入れています。
- 戻り値

``` json
{
    result: true,
    feel: "waai"
}
```

※resultはtrue固定、feelは #13 の目玉の種類をランダムで返します。
- Javadoc
  - http://javajo-erk5.azurewebsites.net/javadoc/javajo/CocoroboController.html
